### PR TITLE
fix path of sound file in examples

### DIFF
--- a/examples/sound.js
+++ b/examples/sound.js
@@ -31,7 +31,7 @@ var qt = require('..');
 
 var app = new qt.QApplication();
 
-var sound = new qt.QSound('conga1.wav');
+var sound = new qt.QSound(__dirname + '/conga1.wav');
 sound.setLoops(3);
 sound.play();
 


### PR DESCRIPTION
`examples/sound.js` doesn't work as my expected.

I tried following code:

``` sh
$ pwd
~/node-qt
$ node examples/sound.js
```

But the sound is never played.

`new qt.QSound();` seems to search file from current path of `node` executed.
I fixed file path to use relative path from `examples/sound.js`
