### PR TITLE
manually calling node-gyp is not needed anymore with recent npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "shelljs": "0.0.5pre4"
   },
   "scripts": {
-    "install": "node-gyp rebuild"
   },
   "devDependencies": {},
   "optionalDependencies": {}


### PR DESCRIPTION
npm will run node-gyp when it finds a binding.gyp in the module, so manually calling node-gyp is not needed anymore
